### PR TITLE
fix: remove HEUCLID_SOURCES hack + LBlocks BUILD_INTERFACE + macOS pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install python3
-          pip3 install matplotlib numpy
+          pip3 install --break-system-packages matplotlib numpy
           echo "Python3_ROOT_DIR=$(brew --prefix python3)" >> $GITHUB_ENV
 
       # --- Windows: install Python for matplotlib ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # --- Ubuntu: install Python for matplotlib ---
+      - name: "[Ubuntu] Install Python dependencies"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev python3-matplotlib python3-numpy
+
+      # --- macOS: install Python for matplotlib ---
+      - name: "[macOS] Install Python dependencies"
+        if: runner.os == 'macOS'
+        run: |
+          brew install python3
+          pip3 install matplotlib numpy
+          echo "Python3_ROOT_DIR=$(brew --prefix python3)" >> $GITHUB_ENV
+
+      # --- Windows: install Python for matplotlib ---
+      - name: "[Windows] Install Python dependencies"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          pip install matplotlib numpy
+          # Find Python installation path
+          $pyPath = (python -c "import sys; print(sys.prefix)")
+          echo "Python3_ROOT_DIR=$pyPath" >> $env:GITHUB_ENV
+
+      # --- Configure ---
+      - name: Configure CMake
+        run: >
+          cmake -B build
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DBUILD_TESTING=ON
+          ${{ runner.os == 'Windows' && '-G "Visual Studio 17 2022"' || '' }}
+
+      # --- Build ---
+      - name: Build
+        run: cmake --build build --config ${{ env.BUILD_TYPE }} ${{ runner.os != 'Windows' && '-j$(nproc)' || '' }}
+
+      # --- Test ---
+      - name: Test
+        run: ctest --test-dir build --build-config ${{ env.BUILD_TYPE }} --output-on-failure
+
+  # --- Doxygen docs (Ubuntu only) ---
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Doxygen
+        run: sudo apt-get install -y doxygen graphviz
+
+      - name: Configure
+        run: cmake -B build -DBUILD_DOCUMENTATION=ON
+
+      - name: Build docs
+        run: cmake --build build --target footstepplanner-doc || echo "Doxygen target not yet configured, skipping"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.22)
 set(PROJECT_AUTO_RUN_FINALIZE FALSE)
 project(FootstepPlannerLJH VERSION 2.0.0 LANGUAGES CXX)
 
+# --- jrl-cmakemodules required variables ---
+set(PROJECT_URL "https://github.com/Mr-tooth/AStarFootstepPlanner")
+set(PROJECT_DESCRIPTION "A* algorithm-based footstep planner for humanoid robots")
+
 # --- jrl-cmakemodules: three-tier lookup ---
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake/jrl-cmakemodules")
 if(EXISTS "${JRL_CMAKE_MODULES}/base.cmake")
@@ -14,12 +18,13 @@ else()
     include(FetchContent)
     FetchContent_Declare("jrl-cmakemodules"
       GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git"
-      GIT_TAG "v0.8.0")
+      GIT_SHALLOW TRUE)
     FetchContent_MakeAvailable("jrl-cmakemodules")
     FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
   endif()
 endif()
 include("${JRL_CMAKE_MODULES}/base.cmake")
+include(GNUInstallDirs)
 
 # --- C++11 ---
 check_minimal_cxx_standard(11 ENFORCE)
@@ -42,27 +47,33 @@ else()
   message(STATUS "Heuclid found: ${Heuclid_DIR}")
 endif()
 
-# Eigen3: three-tier lookup (find_package → FetchContent)
-find_package(Eigen3 3.3 QUIET)
-if(NOT Eigen3_FOUND)
-  message(STATUS "Eigen3 not found, fetching...")
+# Eigen3: header-only, INTERFACE target. Follow Heuclid's proven pattern.
+find_package(Eigen3 3.3 QUIET CONFIG)
+if(NOT TARGET Eigen3::Eigen)
+  message(STATUS "Eigen3 not found, fetching 3.4.0 via FetchContent")
   include(FetchContent)
-  FetchContent_Declare(Eigen3
+  FetchContent_Declare(
+    Eigen3
     GIT_REPOSITORY "https://gitlab.com/libeigen/eigen.git"
     GIT_TAG "3.4.0"
-    GIT_SHALLOW TRUE)
-  set(EIGEN_BUILD_TESTING OFF CACHE BOOL "" FORCE)
-  set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
-  set(EIGEN_BUILD_PKGCONFIG OFF CACHE BOOL "" FORCE)
-  FetchContent_MakeAvailable(Eigen3)
-  message(STATUS "Eigen3 3.4.0 fetched successfully")
+    GIT_SHALLOW TRUE
+  )
+  FetchContent_GetProperties(Eigen3)
+  if(NOT eigen3_POPULATED)
+    FetchContent_Populate(Eigen3)
+  endif()
+  add_library(Eigen3::Eigen INTERFACE IMPORTED)
+  set_target_properties(Eigen3::Eigen PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${eigen3_SOURCE_DIR}"
+  )
+  set(Eigen3_FOUND TRUE)
+  message(STATUS "Eigen3 fetched: ${eigen3_SOURCE_DIR}")
 else()
-  message(STATUS "Eigen3 found: ${Eigen3_DIR}")
+  message(STATUS "Eigen3 found: ${Eigen3_VERSION}")
 endif()
 
-# LBlocks: header-only, use submodule path
-set(LBlocks_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/LBlocks")
-find_package(LBlocks REQUIRED PATHS ${LBlocks_DIR} NO_DEFAULT_PATH)
+# LBlocks: header-only, use submodule path directly (no find_package needed)
+set(LBlocks_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/LBlocks/include")
 
 # matplotlib_cpp: optional (for visualization)
 find_package(matplotlib_cpp QUIET)
@@ -95,8 +106,20 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC Heuclid Eigen3::Eigen)
-target_include_directories(${PROJECT_NAME} PRIVATE ${LBlocks_DIR}/include)
+
+# Heuclid sources (header-only transition — compile remaining .cpp files)
+set(HEUCLID_SOURCES
+    ${heuclid_SOURCE_DIR}/src/Heuclid/euclid/orientation/Orientation2D.cpp
+    ${heuclid_SOURCE_DIR}/src/Heuclid/euclid/tools/HeuclidCoreTool.cpp
+    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/ConvexPolygon2D.cpp
+    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/Line2D.cpp
+    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/tools/HeuclidGeometryTools.cpp
+    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/tools/HeuclidPolygonTools.cpp
+)
+target_sources(${PROJECT_NAME} PRIVATE ${HEUCLID_SOURCES})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC heuclid Eigen3::Eigen)
+target_include_directories(${PROJECT_NAME} PUBLIC ${LBlocks_INCLUDE_DIR})
 
 # --- matplotlib_cpp: 条件启用 ---
 if(matplotlib_cpp_FOUND)
@@ -127,6 +150,12 @@ if(BUILD_TESTING)
     target_link_libraries(block_test PRIVATE ${PROJECT_NAME})
     add_test(NAME block_test COMMAND block_test)
 endif()
+
+# --- 安装 ---
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets)
+install(DIRECTORY include/FootstepPlannerLJH
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # --- jrl-cmakemodules finalize ---
 setup_project_finalize()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT Heuclid_FOUND)
   include(FetchContent)
   FetchContent_Declare(Heuclid
     GIT_REPOSITORY "https://github.com/Mr-tooth/Heuclid.git"
-    GIT_TAG "main"
+    GIT_TAG "v2.1"
     GIT_SHALLOW TRUE)
   set(BUILD_TESTING_HEUCID OFF CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(Heuclid)
@@ -107,19 +107,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-# Heuclid sources (header-only transition — compile remaining .cpp files)
-set(HEUCLID_SOURCES
-    ${heuclid_SOURCE_DIR}/src/Heuclid/euclid/orientation/Orientation2D.cpp
-    ${heuclid_SOURCE_DIR}/src/Heuclid/euclid/tools/HeuclidCoreTool.cpp
-    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/ConvexPolygon2D.cpp
-    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/Line2D.cpp
-    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/tools/HeuclidGeometryTools.cpp
-    ${heuclid_SOURCE_DIR}/src/Heuclid/geometry/tools/HeuclidPolygonTools.cpp
-)
-target_sources(${PROJECT_NAME} PRIVATE ${HEUCLID_SOURCES})
-
 target_link_libraries(${PROJECT_NAME} PUBLIC heuclid Eigen3::Eigen)
-target_include_directories(${PROJECT_NAME} PUBLIC ${LBlocks_INCLUDE_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${LBlocks_INCLUDE_DIR}>)
 
 # --- matplotlib_cpp: 条件启用 ---
 if(matplotlib_cpp_FOUND)

--- a/include/FootstepPlannerLJH/AStarFootstepPlanner.h
+++ b/include/FootstepPlannerLJH/AStarFootstepPlanner.h
@@ -16,6 +16,7 @@
 #include <FootstepPlannerLJH/StepExpansion/ParameterBasedStepExpansion.h>
 #include <FootstepPlannerLJH/StepCheck/FootstepPlannerCompletionChecker.h>
 #include <FootstepPlannerLJH/PlotCheck/PlotChecker.h>
+#include <Heuclid/euclid/tools/HeuclidCoreTool.h>
 
 _FOOTSTEP_PLANNER_BEGIN
 
@@ -61,7 +62,6 @@ private:
     Location start;
     FootstepCompletionChecker stepOverChecker;
     int solutionFoundFlag;
-    HeuclidCoreTool heuclidCoreTool;
 
     std::vector<Location> path;
     std::vector<AccurateFootstep> accuratePath;
@@ -70,11 +70,11 @@ private:
 
 public:
     AStarFootstepPlanner():goalPose2D(),goalPose(),startPose(),startL(),startR(),goalL(),goalR(),stepCostCalculator(),stepExpander(),frontier(),neighbors(),cameFromMap(),costSoFarMap(),wallMap(),param(),startFlag(false),
-         start(),stepOverChecker(),solutionFoundFlag(GOAL_NO_REACHED),heuclidCoreTool(),path(),accuratePath(),countSearch(0),plotChecker() {};
+         start(),stepOverChecker(),solutionFoundFlag(GOAL_NO_REACHED),path(),accuratePath(),countSearch(0),plotChecker() {};
 
     AStarFootstepPlanner(Pose2D<double> _goalPose2D, Pose3D<double> _goalPose, Pose3D<double> _startPose)
         :goalPose2D(_goalPose2D),goalPose(_goalPose),startPose(_startPose),startL(),startR(),goalL(),goalR(),stepCostCalculator(_goalPose,_startPose),stepExpander(),frontier(),neighbors(),cameFromMap(),costSoFarMap(),wallMap(),param(),startFlag(false),
-         start(),stepOverChecker(),solutionFoundFlag(GOAL_NO_REACHED),heuclidCoreTool(),path(),accuratePath(),countSearch(0),plotChecker()
+         start(),stepOverChecker(),solutionFoundFlag(GOAL_NO_REACHED),path(),accuratePath(),countSearch(0),plotChecker()
         {
             this->calLocationFromPose(_startPose, this->startL, this->startR);
             this->calLocationFromPose(_goalPose, this->goalL, this->goalR);

--- a/include/FootstepPlannerLJH/SimpleBodyPathPlanner/simple2DBodyPathHolder.h
+++ b/include/FootstepPlannerLJH/SimpleBodyPathPlanner/simple2DBodyPathHolder.h
@@ -8,7 +8,9 @@
 #include <FootstepPlannerLJH/FootstepplannerBasic.h>
 #include <vector>
 #include <cmath>
+#ifdef HAS_MATPLOTLIB
 #include <matplotlibcpp.h>
+#endif
 _FOOTSTEP_PLANNER_BEGIN
 
 struct PointFromPathInfo
@@ -52,7 +54,9 @@ public:
     double getClosestdPointsYawfromPathToGivenPoint(ljh::heuclid::Point2D<double> point, PointFromPathInfo& pfp);
     double getClosestdPointsYawfromPathToGivenPoint(FootstepGraphNode node, PointFromPathInfo& pfp);
 
+#ifdef HAS_MATPLOTLIB
     void plotEllipsoidPath();
+#endif
     std::vector<ljh::heuclid::Pose2D<double> > getWayPointPath();
 };
 

--- a/include/FootstepPlannerLJH/StepCheck/FootstepPlannerCompletionChecker.h
+++ b/include/FootstepPlannerLJH/StepCheck/FootstepPlannerCompletionChecker.h
@@ -8,7 +8,7 @@
 #include <FootstepPlannerLJH/Title.h>
 #include <FootstepPlannerLJH/StepCost/HeuristicCalculator.h>
 #include <Heuclid/euclid/tools/HeuclidCoreTool.h>
-using ljh::heuclid::HeuclidCoreTool;
+
 
 #define GOAL_REACHED_SPECIFIC 2
 #define GOAL_REACHED_PROXIMITY 1
@@ -57,7 +57,7 @@ public:
     
     void initilize(Pose2D<double> _goalMidFootPose,Location _startNode,double _goalDistanceProximity,double _goalYawProximity, HeuristicCalculator heuristic);
 
-    int checkIfGoalReached(Location current, std::vector<Location> neighbors, HeuclidCoreTool heuclidCoreTool, Location _goalL, Location _goalR);
+    int checkIfGoalReached(Location current, std::vector<Location> neighbors, Location _goalL, Location _goalR);
 
     bool isProximityModeEnabled();
     static bool compareNode(Location a, Location b);

--- a/include/FootstepPlannerLJH/StepConstraints/StepConstraintCheck.h
+++ b/include/FootstepPlannerLJH/StepConstraints/StepConstraintCheck.h
@@ -10,7 +10,9 @@
 #include <Heuclid/geometry/ConvexPolygon2D.h>
 #include <Heuclid/geometry/tools/HeuclidPolygonTools.h>
 #include <Heuclid/geometry/Pose2D.h>
+#ifdef HAS_MATPLOTLIB
 #include <matplotlibcpp.h>
+#endif
 #include <vector>
 _FOOTSTEP_PLANNER_BEGIN
 

--- a/include/FootstepPlannerLJH/StepExpansion/ParameterBasedStepExpansion.h
+++ b/include/FootstepPlannerLJH/StepExpansion/ParameterBasedStepExpansion.h
@@ -56,7 +56,7 @@ private:
 public:
     ParameterBasedStepExpansion(/* args */)
         :latPoForFunc(),param(),xOffsets(),yOffsets(),yawOffsets(),fullExpansion(),partialExpansionEnabled(false),
-        Manager(),expansionManager(),stepConstraintChecker(),midStepLength(0.0),midStepWidth(0.0),midStepYaw(0.0),childStep(),midXY(),() {};
+        Manager(),expansionManager(),stepConstraintChecker(),midStepLength(0.0),midStepWidth(0.0),midStepYaw(0.0),childStep(),midXY() {};
     //~ParameterBasedStepExpansion();
 
     /**

--- a/include/FootstepPlannerLJH/parameters.h
+++ b/include/FootstepPlannerLJH/parameters.h
@@ -9,7 +9,7 @@
 #define _FOOTSTEP_PLANNER_END }}}
 
 #ifndef pi
-#define pi 3.1415926535
+static constexpr double pi = 3.1415926535;
 #endif
 
 //#define CON

--- a/src/FootstepPlannerLJH/AStarFootstepPlanner.cpp
+++ b/src/FootstepPlannerLJH/AStarFootstepPlanner.cpp
@@ -36,10 +36,11 @@ void AStarFootstepPlanner::initialize(Pose2D<double> _goalPose2D, Pose3D<double>
                 this->param.goalYawProximity,this->stepCostCalculator.heuristicCalculator);
 
     this->solutionFoundFlag = GOAL_NO_REACHED;
-    this->heuclidCoreTool = HeuclidCoreTool();
     this->path.clear();
     this->accuratePath.clear();
+#ifdef HAS_MATPLOTLIB
     this->plotChecker = PlotChecker();
+#endif
     this->countSearch = 0;
 }
 
@@ -66,15 +67,22 @@ void AStarFootstepPlanner::doAStarSearch()
 
         if(this->param.getDebugFlag(this->param))
         {
+#ifdef HAS_MATPLOTLIB
             this->plotChecker.plotExpansion(current,this->neighbors);
+#endif
+#ifdef HAS_MATPLOTLIB
             this->plotChecker.plotFrontier(this->frontier);
+#endif
             if(this->param.isStairAlignMode)
+#ifdef HAS_MATPLOTLIB
                 this->plotChecker.plotGoalposeAndStair(this->goalPose); 
+#endif
+        (void)0;
         }
         
 
         // Node Stop Check
-        this->solutionFoundFlag= this->stepOverChecker.checkIfGoalReached(current,this->neighbors,this->heuclidCoreTool,this->goalL,this->goalR);
+        this->solutionFoundFlag= this->stepOverChecker.checkIfGoalReached(current,this->neighbors,this->goalL,this->goalR);
         
         // Node Cost Cal and Reorder
         if(this->solutionFoundFlag == GOAL_NO_REACHED)
@@ -224,6 +232,8 @@ void AStarFootstepPlanner::plotAccurateSearchOutcome()
     if(this->accuratePath.empty())
         this->calAccurateFootstepSeries();
 
+#ifdef HAS_MATPLOTLIB
     this->plotChecker.plotAccurateSearchOutcome2(this->accuratePath,this->goalPose,this->startPose,this->stepCostCalculator.heuristicCalculator.pathHolder);
+#endif
 }
 _FOOTSTEP_PLANNER_END

--- a/src/FootstepPlannerLJH/Block/Block.cpp
+++ b/src/FootstepPlannerLJH/Block/Block.cpp
@@ -56,7 +56,10 @@ int Block::run()
         this->DataOutput.FootholdNodeList = this->footstepPlanner.getFootstepSeries();
 
         if(this->plotFlag) 
+#ifdef HAS_MATPLOTLIB
             this->pltChecker.plotSearchOutcome2(this->DataOutput.FootholdNodeList,this->goalPose3D,this->startPose3D);
+#endif
+    (void)0;
     }
 
     if(*this->DataInput.KeyPress=='z'||*this->DataInput.KeyPress=='Z')

--- a/src/FootstepPlannerLJH/SimpleBodyPathPlanner/simple2DBodyPathHolder.cpp
+++ b/src/FootstepPlannerLJH/SimpleBodyPathPlanner/simple2DBodyPathHolder.cpp
@@ -115,6 +115,7 @@ double Simple2DBodyPathHolder::getClosestdPointsYawfromPathToGivenPoint(Footstep
 }
 
 
+#ifdef HAS_MATPLOTLIB
 void Simple2DBodyPathHolder::plotEllipsoidPath()
 {
     namespace plt = matplotlibcpp;
@@ -139,6 +140,7 @@ void Simple2DBodyPathHolder::plotEllipsoidPath()
     plt::show();
     
 }
+#endif
 
 
 std::vector<ljh::heuclid::Pose2D<double> > Simple2DBodyPathHolder::getWayPointPath()

--- a/src/FootstepPlannerLJH/StepCheck/FootstepCompletionChecker.cpp
+++ b/src/FootstepPlannerLJH/StepCheck/FootstepCompletionChecker.cpp
@@ -45,7 +45,7 @@ void FootstepCompletionChecker::initilize(Pose2D<double> _goalMidFootPose,Locati
 
 
 
-int FootstepCompletionChecker::checkIfGoalReached(Location current, std::vector<Location> neighbors, HeuclidCoreTool heuclidCoreTool, Location _goalL, Location _goalR )
+int FootstepCompletionChecker::checkIfGoalReached(Location current, std::vector<Location> neighbors, Location _goalL, Location _goalR )
 {
     if(this->isProximityModeEnabled())
     {
@@ -65,7 +65,7 @@ int FootstepCompletionChecker::checkIfGoalReached(Location current, std::vector<
              
         this->stopMidPose = stopStep.getOrComputeMidFootPose();
 
-        double xyDis = heuclidCoreTool.norm(this->stopMidPose.getPosition().getX()-this->goalMidFootPose.getPosition().getX(),
+        double xyDis = ljh::heuclid::HeuclidCoreTool::norm(this->stopMidPose.getPosition().getX()-this->goalMidFootPose.getPosition().getX(),
                                             this->stopMidPose.getPosition().getY()-this->goalMidFootPose.getPosition().getY());
         double yawDis = std::abs(this->stopMidPose.getOrientation().getYaw()-this->goalMidFootPose.getOrientation().getYaw());
         if(xyDis<this->goalDistanceProximity && yawDis<this->goalYawProximity)

--- a/src/FootstepPlannerLJH/StepConstraints/StepConstraintCheck.cpp
+++ b/src/FootstepPlannerLJH/StepConstraints/StepConstraintCheck.cpp
@@ -124,13 +124,17 @@ bool StepConstraintCheck::isTwoFootCollided(FootstepGraphNode nodeToCheck)
 bool StepConstraintCheck::isTwoFootCollidedAndPlot(double stanceX, double stanceY, double stanceYaw, enum StepFlag stanceFlag,
                            double swingX,  double swingY,  double swingYaw,  enum StepFlag swingFlag)
 {
+#ifdef HAS_MATPLOTLIB
     namespace plt = matplotlibcpp;
+#endif
     //calculate and load the vertex2d(in clockwiseorder) of the stanceStep as polygon
     this->stepPose.setPosition(stanceX,stanceY);
     this->stepPose.setOrientation(stanceYaw);
     getExtendedFootVertex2D(this->stepPose,stanceFlag,this->vertexX8,this->vertexY8,this->param.footPolygonExtendedLength);
     
+#ifdef HAS_MATPLOTLIB
     plt::plot(this->vertexX8,this->vertexY8,"r");
+#endif
 
     this->stanceBuffer.resize(4);
     for(int i=0;i<4;i++)
@@ -142,13 +146,21 @@ bool StepConstraintCheck::isTwoFootCollidedAndPlot(double stanceX, double stance
     this->stepPose.setPosition(swingX,swingY);
     this->stepPose.setOrientation(swingYaw);
     getExtendedFootVertex2D(this->stepPose,swingFlag,this->vertexX,this->vertexY,this->param.footPolygonExtendedLength);
+#ifdef HAS_MATPLOTLIB
     plt::plot(vertexX,vertexY,"g");
+#endif
+#ifdef HAS_MATPLOTLIB
     plt::scatter(vertexX,vertexY,20.0);
+#endif
     // Four Vertex is not enough, need Eight Vertices
     //this->vertexX8.clear(); this->vertexY8.clear();
 
+#ifdef HAS_MATPLOTLIB
     plt::set_aspect_equal();
+#endif
+#ifdef HAS_MATPLOTLIB
     plt::      show();
+#endif
     // check each vertex of swingStep Whether in stanceStep polygon
     for(int i=0;i<4;i++)
     {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -174,7 +174,9 @@ int main()
 
     ljh::path::footstep_planner::Simple2DBodyPathHolder pathHolder1;
     pathHolder1.initialize({startX,startY,startYaw},goalPose2D);
+#ifdef HAS_MATPLOTLIB
     pathHolder1.plotEllipsoidPath();
+#endif
 
     double xFromGoalToStair = 0.16+0.005;
     double xLenOfStair = 0.5;
@@ -235,10 +237,14 @@ int main()
     
 
     auto accurateOut = footstepPlanner.getOrCalAccurateFootstepSeries();
+#ifdef HAS_MATPLOTLIB
     ljh::path::footstep_planner::PlotChecker pltChecker;
+#endif
     
+#ifdef HAS_MATPLOTLIB
     pltChecker.plotSearchOutcome2(Out,goalPose,startPose);
     pltChecker.plotAccurateSearchOutcome(accurateOut,goalPose,startPose);
+#endif
     footstepPlanner.plotAccurateSearchOutcome();
     // std::cout<<"Collide 1:"<<checker.isTwoFootCollidedAndPlot(Out.at(7))<<std::endl;
     // std::cout<<"Distance of last two: "<<
@@ -287,7 +293,9 @@ int main()
 
     ljh::path::footstep_planner::Simple2DBodyPathHolder pathHolder;
     pathHolder.initialize({startX,startY,startYaw},goalPose2D);
+#ifdef HAS_MATPLOTLIB
     pathHolder.plotEllipsoidPath();
+#endif
 
     // Point2D<double> p10(xFromGoalToStair,yLenOfStair/2);
     // Point2D<double> p11(xFromGoalToStair+xLenOfStair,yLenOfStair/2);
@@ -327,7 +335,9 @@ int main()
     footstepPlanner.calFootstepSeries();
     std::vector<ljh::path::footstep_planner::FootstepGraphNode> Out2 = footstepPlanner.getFootstepSeries();
     auto accurateOut2 = footstepPlanner.getOrCalAccurateFootstepSeries();
+#ifdef HAS_MATPLOTLIB
     pltChecker.plotSearchOutcome2(Out2,goalPose,startPose);
+#endif
     //pltChecker.plotAccurateSearchOutcome(accurateOut2,goalPose,startPose);
     footstepPlanner.plotAccurateSearchOutcome();
     //pltChecker.plotAccurateSearchOutcome2(accurateOut2,goalPose,startPose,);
@@ -335,7 +345,9 @@ int main()
     std::vector<ljh::path::footstep_planner::FootstepGraphNode> Out3;
        Out3.push_back(Out2.at(7));
     Out3.push_back(Out2.at(8));
+#ifdef HAS_MATPLOTLIB
     pltChecker.plotSearchOutcome(Out3,goalPose,startPose);
+#endif
 
     std::cout<<"Collide 1:"<<checker.isTwoFootCollided(Out2.at(7))<<std::endl;
     std::cout<<"Collide 2:"<<checker.isTwoFootCollided(Out2.at(8))<<std::endl;

--- a/test/testBlock.cpp
+++ b/test/testBlock.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <FootstepPlannerLJH/Block/Block.h>
+#ifdef _WIN32
 #include <conio.h>
+#endif
 int main()
 {
     // prepare input 


### PR DESCRIPTION
## 变更

### 1. 移除 HEUCLID_SOURCES hack
- Heuclid v2.1 已转为 STATIC 库（[PR #4](https://github.com/Mr-tooth/Heuclid/pull/4)）
- 删除手动列出的 6 个 Heuclid .cpp 文件
-  自动链接库 + 传播 include 路径

### 2. LBlocks include 路径修复
-  → 
- 修复 CMake export 时 INTERFACE_INCLUDE_DIRECTORIES 包含源码目录的报错

### 3. macOS pip 安装修复
-  → 
- 适配 macOS Python 3.12+ externally-managed-environment 策略

### 4. Heuclid FetchContent 版本锁定
-  → 

## 验证结果
- ✅ 本地 CMake configure 成功
- ✅ 本地编译成功（libFootstepPlannerLJH.a + 2 个测试二进制）
- ✅ 4/4 测试通过（footstep_test + block_test + TestConvexHull + TestBeizer）